### PR TITLE
Fix wrong ref usage in std.typecons.setField().

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7329,11 +7329,17 @@ ref Field refField(Field, Obj)(return ref Obj obj, string name) if (!is(Obj == c
  *     name = the name of the field or property member
  *     value = the new value to assign to the member
  */
-void setField(Field, Obj)(auto ref Obj obj, string name, auto ref Field value)
+void setField(Field, Obj)(Obj obj, string name, auto ref Field value) if (is(Obj == class))
 {
-    enum refField = !is(Field == class) || (Field.sizeof > 16);
-    enum refObj = !is(Obj == class) || (Obj.sizeof > 16);
-    rtFieldDispatch!(true, Field, refField, Obj, refObj)(obj, name, value);
+    enum refField = !is(Field == class) && (Field.sizeof > 16);
+    rtFieldDispatch!(true, Field, refField, Obj, false)(obj, name, value);
+}
+
+/// ditto
+void setField(Field, Obj)(ref Obj obj, string name, auto ref Field value) if (!is(Obj == class))
+{
+    enum refField = !is(Field == class) && (Field.sizeof > 16);
+    rtFieldDispatch!(true, Field, refField, Obj, true)(obj, name, value);
 }
 
 ///


### PR DESCRIPTION
I just noticed that messed up the `ref` usage for `setField()` pretty badly: non-class `Obj` types must always be passed by `ref` to `setField()` (regardless of size), otherwise the changes made won't stick. This mistake was being masked by the fact that I _also_ accidentally wrote `||` where I meant to write `&&`.
