### PR TITLE
Better error handling for rtFieldDispatch()

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -231,9 +231,10 @@ assert([4, 7, 5].enumerate.maxElement!`a.value` == tuple(1, 7));
 
 $(LI $(LNAME2 getField, Added runtime member getting and setting
     via `std.typecons.getField` and `std.typecons.setField`.)
-    $(P $(XREF typecons, getField), $(XREF typecons, refField), and
-    $(XREF typecons, setField) allow scripting language style setting of
-    type fields from runtime generated strings.
+    $(P $(XREF typecons, getField), $(XREF typecons, tryGetField),
+    $(XREF typecons, refField), $(XREF typecons, setField), and
+    $(XREF typecons, trySetField) allow scripting language style
+    setting of type fields from runtime generated strings.
     )
 
 -------


### PR DESCRIPTION
The `tryGetField()` and `trySetField()` functions are `nothrow @nogc`, and return a `bool` indicating success (`true`) or failure (`false`). The others throw an exception.

I did not include a `@nogc` version of `refField()`. I can add one if you want, but it would have to return the reference via an `out Field*` parameter to allow returning `false` and setting a `null` reference if it fails.
